### PR TITLE
Fix incorrect lexicographical comparison preventing double-digit Facet Versions (e.g., Jakarta EE 10)

### DIFF
--- a/plugins/org.eclipse.wst.common.modulecore/modulecore-src/org/eclipse/wst/common/componentcore/datamodel/FacetProjectCreationDataModelProvider.java
+++ b/plugins/org.eclipse.wst.common.modulecore/modulecore-src/org/eclipse/wst/common/componentcore/datamodel/FacetProjectCreationDataModelProvider.java
@@ -341,7 +341,7 @@ public class FacetProjectCreationDataModelProvider extends AbstractDataModelProv
 							IDataModel facetModel = ((FacetDataModelMap) facetDMs).getFacetDataModel(facet.getId());
 							IProjectFacetVersion oldVersion = (IProjectFacetVersion) facetModel.getProperty(IFacetDataModelProperties.FACET_VERSION);
 							IProjectFacetVersion newVersion = facet.getLatestSupportedVersion(runtime);
-							if (newVersion != null && (oldVersion == null || oldVersion.getVersionString().compareTo(newVersion.getVersionString()) > 0 || !runtime.supports(oldVersion))) {
+							if (newVersion != null && (oldVersion == null || oldVersion.compareTo(newVersion) > 0 || !runtime.supports(oldVersion))) {
 								facetModel.setProperty(IFacetDataModelProperties.FACET_VERSION, newVersion);
 							}
 						} catch (CoreException e) {


### PR DESCRIPTION
There is a logic error in the Data Model Provider where facet versions are compared using `String.compareTo()` on their version strings. This causes incorrect evaluation for double digit versions (common in Jakarta EE 10+).

The current code compares versions as raw Strings:
```java
oldVersion.getVersionString().compareTo(newVersion.getVersionString())
```

Since `String.compareTo` performs a lexicographical comparison:
*   `"10.0"` is considered **less than** `"2.0"` (because '1' < '2').
*   `"10.0"` is considered **less than** `"9.0"`.

This logic causes the wizard to incorrectly determine that a newer version (e.g., 10.0) is "older" when handling Jakarta EE 10+ facets.

#### Fix
The `IProjectFacetVersion` interface extends `Comparable<IProjectFacetVersion>`. The comparison should use the object's native comparison logic, which handles numerical versioning correctly.

This fix is required to correctly support **Jakarta EE 10** (EAR 10.0, AppClient 10.0) and future versions where version numbers exceed single digits. Also, should fix a related issue in [open liberty tools](https://github.com/OpenLiberty/open-liberty-tools/pull/543)