### PR TITLE
Address Snippet issues

### DIFF
--- a/plugins/org.eclipse.wst.common.snippets/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.wst.common.snippets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Snippets_View.name
 Bundle-SymbolicName: org.eclipse.wst.common.snippets; singleton:=true
 Automatic-Module-Name: org.eclipse.wst.common.snippets
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.wst.common.snippets.internal.SnippetsPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -19,6 +19,7 @@ Export-Package: org.eclipse.wst.common.snippets.core,
  org.eclipse.wst.common.snippets.internal.util;x-internal:=true,
  org.eclipse.wst.common.snippets.ui
 Require-Bundle: org.eclipse.gef;bundle-version="[3.10.0,6.0.0)",
+ org.eclipse.jface;bundle-version="[3.33.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.12.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",

--- a/plugins/org.eclipse.wst.common.snippets/pom.xml
+++ b/plugins/org.eclipse.wst.common.snippets/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2018 Eclipse Foundation and others.
+  Copyright (c) 2012, 2026 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.webtools.common</groupId>
   <artifactId>org.eclipse.wst.common.snippets</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/SnippetsPlugin.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/SnippetsPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package org.eclipse.wst.common.snippets.internal;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.wst.common.snippets.internal.model.SnippetManager;
+import org.osgi.framework.BundleContext;
 
 
 /**
@@ -72,5 +73,18 @@ public class SnippetsPlugin extends AbstractUIPlugin {
 	public SnippetsPlugin() {
 		super();
 		fInstance = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		try {
+			SnippetManager.getInstance().saveDefinitions();
+		}
+		catch (Exception e) {
+			Logger.logException("could not save snippet definitions on shutdown", e); //$NON-NLS-1$
+		}
+		finally {
+			super.stop(context);
+		}
 	}
 }

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/model/SnippetManager.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/model/SnippetManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -210,6 +210,7 @@ public class SnippetManager implements ISnippetManager, PropertyChangeListener {
 	public SnippetPaletteRoot getPaletteRoot() {
 		if (fRoot == null) {
 			fRoot = new SnippetPaletteRoot(getDefinitions());
+			fRoot.connect();
 		}
 		return fRoot;
 	}

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/palette/SnippetCustomizerDialog.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/palette/SnippetCustomizerDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2022 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -246,7 +246,7 @@ public class SnippetCustomizerDialog extends PaletteCustomizerDialog {
 
 	private class ImportAction extends PaletteCustomizationAction {
 		public ImportAction() {
-			setEnabled(false);
+			setEnabled(true);
 			setText(SnippetsMessages.SnippetCustomizerDialog_0);
 			SnippetsPluginImageHelper pluginImageHelper = SnippetsPluginImageHelper.getInstance();
 			setImageDescriptor(pluginImageHelper.getImageDescriptor(SnippetsPluginImages.IMG_ELCL_IMPORT));
@@ -325,14 +325,7 @@ public class SnippetCustomizerDialog extends PaletteCustomizerDialog {
 		}
 
 		public void update() {
-			boolean enabled = false;
-			PaletteEntry entry = getSelectedPaletteEntry();
-			if (entry != null) {
-				if (getCustomizer() instanceof SnippetsCustomizer) {
-					enabled = ((SnippetsCustomizer) getCustomizer()).canImport(entry);
-				}
-			}
-			setEnabled(enabled);
+			setEnabled(getCustomizer() instanceof SnippetsCustomizer);
 		}
 	}
 

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/palette/UserModelDumper.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/palette/UserModelDumper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2022 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -264,8 +264,7 @@ public class UserModelDumper {
 	}
 
 	public void write(SnippetDefinitions definitions) {
-		try {
-			FileOutputStream ostream = new FileOutputStream(getFilename());
+		try (FileOutputStream ostream = new FileOutputStream(getFilename())) {
 			write(definitions, ostream);
 		}
 		catch (IOException e) {
@@ -283,7 +282,6 @@ public class UserModelDumper {
 			Logger.log(Logger.ERROR, "could not save " + stream, e); //$NON-NLS-1$
 		}
 		finally {
-			//				stream.close();
 			document = null;
 		}
 	}

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/ui/SnippetsView.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/ui/SnippetsView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -609,8 +609,7 @@ public class SnippetsView extends ViewPart {
 	 */
 	public void dispose() {
 		super.dispose();
-		if (fRoot != null)
-			fRoot.disconnect();
+		SnippetManager.getInstance().getPaletteRoot().disconnect();
 		if (clipboard != null)
 			clipboard.dispose();
 		if (fPartActionUpdateListener != null)

--- a/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/util/AccessibleTableViewer.java
+++ b/plugins/org.eclipse.wst.common.snippets/src/org/eclipse/wst/common/snippets/internal/util/AccessibleTableViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -229,9 +229,12 @@ public class AccessibleTableViewer extends StructuredViewer {
 
 			IBaseLabelProvider prov = getLabelProvider();
 			ITableLabelProvider tprov = null;
-			ILabelProvider lprov = (ILabelProvider) prov;
+			ILabelProvider lprov = null;
 			if (prov instanceof ITableLabelProvider) {
 				tprov = (ITableLabelProvider) prov;
+			}
+			else if (prov instanceof ILabelProvider) {
+				lprov = (ILabelProvider) prov;
 			}
 			int columnCount = fTable.getColumnCount();
 			// Also enter loop if no columns added. See 1G9WWGZ: JFUIF:WINNT -


### PR DESCRIPTION
`SnippetsPlugin` was missing a `stop()` method, so snippets were never saved when Eclipse closed normally. `UserModelDumper` opened a `FileOutputStream` to write `user.xml` but never closed it (the close call was commented out), leaving the file at 0 bytes on exit.
 
The deeper persistence bug was in `SnippetManager.getPaletteRoot()`, which created the palette root without calling `connect()`. This meant the manager was never notified when snippets were added (e.g. via import), so `saveDefinitions()` always wrote stale data. Related to this, `SnippetsView.dispose()` was calling `disconnect()` on a field that was always null.
 
The Import button in the Customize dialog was always greyed out because it was initialized disabled and only enabled on selection. So fixed to be enabled by default. Finally, `AccessibleTableViewer` was unconditionally casting the label provider to `ILabelProvider` before checking its type, causing a crash due to OSGi classloader isolation. `org.eclipse.jface` was also added as an explicit `Require-Bundle` dependency since relying on it transitively doesn't guarantee classloader sharing.